### PR TITLE
add i18n support for message and buttons

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,9 @@
+[matomo_track_button]
+  other="Allow Analysis"
+[matomo_track_message]
+  other="Thanks for providing analysis data and helping me make the blog better!"
+[matomo_block_button]
+  other="Disallow Analysis"
+[matomo_block_message]
+  other="Unfortunately you do not allow me to use your data for improving the blog."
+

--- a/layouts/shortcodes/matomo-optout.html
+++ b/layouts/shortcodes/matomo-optout.html
@@ -19,8 +19,8 @@
 <link rel="stylesheet" href="{{ $matomoStyle.RelPermalink }}" {{ if not $.Site.Params.matomo.disableSRI }}integrity="{{ $matomoStyle.Data.Integrity }}" crossorigin="anonymous"{{ end }}>
 {{- end -}}
 {{ end }}
-<div class="MatomoOptout-message MatomoOptout-message--track is-hidden">{{ $.Page.Param "matomo.track.message" | default "You are being watched." | markdownify }}</div>
-<div class="MatomoOptout-message MatomoOptout-message--block">{{ $.Page.Param "matomo.block.message" | default "You are not tracked." | markdownify }}</div>
-<button class="MatomoOptout-button MatomoOptout-button--track">{{ $.Page.Param "matomo.track.button" | default "Allow tracking"}}</button> 
-<button class="MatomoOptout-button MatomoOptout-button--block">{{ $.Page.Param "matomo.block.button" | default "Disable tracking"}}</button>
+<div class="MatomoOptout-message MatomoOptout-message--track is-hidden">{{ i18n "matomo_track_message" | default "You are being watched." | markdownify }}</div>
+<div class="MatomoOptout-message MatomoOptout-message--block">{{ i18n "matomo_block_message" | default "You are not tracked." | markdownify }}</div>
+<button class="MatomoOptout-button MatomoOptout-button--track">{{ i18n "matomo_track_button" | default "Allow tracking"}}</button> 
+<button class="MatomoOptout-button MatomoOptout-button--block">{{ i18n "matomo_block_button" | default "Disable tracking"}}</button>
 </div>


### PR DESCRIPTION
Hey, awesome plugin you have there. 

Unfortunately i18n was missing. I quickly implemented and thought i'd share the PR with you, so you can use the change upstream.

What do you think about it?

Downside is that the old parameters won't work anymore and users now have to change the text fields in matomo/i18n/en.toml (or whatever other language they use) 

For me it works fine with a bilingual blog in English and German.